### PR TITLE
Use req.backend.is_origin instead of !req.backend.is_shield

### DIFF
--- a/config_examples/waflyctl.toml.example
+++ b/config_examples/waflyctl.toml.example
@@ -74,6 +74,6 @@ content = "403 Forbidden"
 
 [prefetch]
 name = "WAF_Prefetch"
-statement = "!req.backend.is_shield"
+statement = "req.backend.is_origin"
 type = "PREFETCH"
 priority = 10


### PR DESCRIPTION
As the condition is not negative and easier to understand.