### PR TITLE
Backup Refactor RFC

### DIFF
--- a/apiharness.go
+++ b/apiharness.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	rsRules = regexp.MustCompile(`^/service/([^/]+)/wafs/([^/]+)/rule_statuses$`)
+	rsOWASP = regexp.MustCompile(`^/service/([^/]+)/wafs/([^/]+)/owasp$`)
+)
+
+// APIHarness encapsulates http.Server and provides functions specific to the
+// Fastly API test harness.
+type APIHarness struct {
+	Listener net.Listener
+}
+
+// Start opens a listener on the next available port on the local system
+func (h *APIHarness) Start() (int, error) {
+	var err error
+	h.Listener, err = net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+
+	p := h.Listener.Addr().(*net.TCPAddr).Port
+	fmt.Printf("Started test server on port: %v\n", p)
+	go http.Serve(h.Listener, h)
+
+	return p, nil
+}
+
+// Stop closes the listener
+func (h *APIHarness) Stop() {
+	// just closing the listener isn't very graceful, but it doesn't need to be,
+	// it is accessed by only the tests, and Stop() is only invoked after tests
+	// have completed.
+	err := h.Listener.Close()
+
+	if err != nil {
+		fmt.Printf("Error stopping test server. %s\n", err)
+	}
+
+	fmt.Printf("Stopped test server\n")
+}
+
+// TODO: This whole handler things is rubbish, think of a better way to do it
+func (h *APIHarness) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	fmt.Printf("Test Server: received path: %s\n", getFullPath(r.URL.Path, r.URL.RawQuery))
+	switch {
+
+	// Handle OWASP Settings
+	case rsOWASP.MatchString(r.URL.Path):
+
+		// load owasp settings from file
+		ow, err := loadOWASPSettings()
+		if err != nil {
+			returnError(w, r, errors.New("error loading OWASP settings"))
+		}
+
+		//build the response object
+		js, err := json.Marshal(ow)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		fmt.Fprintf(w, "%s", js)
+
+	// Handle Rules
+	case rsRules.MatchString(r.URL.Path):
+		res := rsRules.FindAllStringSubmatch(r.URL.Path, -1)
+		wid := res[0][2]
+
+		// load test rules from file
+		rs, err := loadRules()
+		if err != nil {
+			returnError(w, r, errors.New("error loading rules"))
+		}
+
+		// capture page numbers & size
+		pn, ps := 1, 3
+		if pss, ok := r.URL.Query()["page[size]"]; ok {
+			i, err := strconv.Atoi(pss[0])
+			if err == nil {
+				ps = i
+			}
+		}
+		if pns, ok := r.URL.Query()["page[number]"]; ok {
+			i, err := strconv.Atoi(pns[0])
+			if err == nil {
+				pn = i
+			}
+		}
+
+		// build the new rule list
+		var rl RuleList
+		rl.Data = extractRules(rs, pn, ps)
+		rl.Meta.CurrentPage = pn
+		rl.Meta.PerPage = ps
+		rl.Meta.RecordCount = len(rs)
+		rl.Meta.TotalPages = int(math.Ceil(float64(len(rs)) / float64(ps)))
+
+		// build the response object
+		js, err := json.Marshal(rl)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// substitute tokens
+		jss := strings.Replace(string(js), "{{waf-id}}", wid, -1)
+
+		// write to response stream
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		fmt.Fprintf(w, "%s", []byte(jss))
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+}
+
+func extractRules(ir []Rule, pn int, ps int) []Rule {
+	// extract start
+	st := (pn - 1) * ps
+	if len(ir) < ps {
+		return ir
+	}
+	ir = ir[st:]
+
+	// check length & trim
+	if len(ir) > ps {
+		return ir[0:ps]
+	}
+	return ir
+
+}
+
+func loadRules() ([]Rule, error) {
+	var rs []Rule
+	rp := "apitestdata/rules.json"
+	b, err := ioutil.ReadFile(rp)
+	if err != nil {
+		return rs, fmt.Errorf("error reading rules file. %s", err)
+	}
+
+	err = json.Unmarshal(b, &rs)
+	if err != nil {
+		return rs, fmt.Errorf("error unmarshalling rules. %s", err)
+	}
+
+	return rs, nil
+}
+
+func loadOWASPSettings() (interface{}, error) {
+	var ow interface{}
+	rp := "apitestdata/owasp.json"
+	b, err := ioutil.ReadFile(rp)
+	if err != nil {
+		return ow, fmt.Errorf("error reading OWASP settings file. %s", err)
+	}
+
+	err = json.Unmarshal(b, &ow)
+	if err != nil {
+		return ow, fmt.Errorf("error unmarshalling OWASP settings. %s", err)
+	}
+
+	return ow, nil
+}
+
+func getFullPath(p, q string) string {
+	if len(q) == 0 {
+		return p
+	}
+	return fmt.Sprintf("%s?%s", p, q)
+}
+
+func returnError(w http.ResponseWriter, r *http.Request, err error) {
+	w.WriteHeader(http.StatusBadRequest)
+}

--- a/apiharness_test.go
+++ b/apiharness_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestExtractRules(t *testing.T) {
+
+	tests := []struct {
+		testid     string
+		rules      []Rule
+		pagenumber int
+		pagesize   int
+		expected   []Rule
+	}{
+		{
+			"Extract Page 1 of Size 1",
+			[]Rule{{ID: "001"}, {ID: "002"}, {ID: "003"}, {ID: "004"}, {ID: "005"}, {ID: "006"}, {ID: "007"}, {ID: "008"}},
+			1,
+			1,
+			[]Rule{{ID: "001"}},
+		},
+		{
+			"Extract Page 1 of Size 3",
+			[]Rule{{ID: "001"}, {ID: "002"}, {ID: "003"}, {ID: "004"}, {ID: "005"}, {ID: "006"}, {ID: "007"}, {ID: "008"}},
+			1,
+			3,
+			[]Rule{{ID: "001"}, {ID: "002"}, {ID: "003"}},
+		},
+		{
+			"Extract Page Larger than Input",
+			[]Rule{{ID: "001"}, {ID: "002"}},
+			1,
+			3,
+			[]Rule{{ID: "001"}, {ID: "002"}},
+		},
+		{
+			"Extract Page 2 of Size 3",
+			[]Rule{{ID: "001"}, {ID: "002"}, {ID: "003"}, {ID: "004"}, {ID: "005"}, {ID: "006"}, {ID: "007"}, {ID: "008"}},
+			2,
+			3,
+			[]Rule{{ID: "004"}, {ID: "005"}, {ID: "006"}},
+		},
+		{
+			"Extract Page 3 of Size 3",
+			[]Rule{{ID: "001"}, {ID: "002"}, {ID: "003"}, {ID: "004"}, {ID: "005"}, {ID: "006"}, {ID: "007"}, {ID: "008"}},
+			3,
+			3,
+			[]Rule{{ID: "007"}, {ID: "008"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			actual := extractRules(tt.rules, tt.pagenumber, tt.pagesize)
+
+			if !RulesEqual(actual, tt.expected) {
+				t.Errorf("Unexpected output, expected (len:%d): %v, actual (len%d) %v", len(tt.expected), tt.expected, len(actual), actual)
+			}
+
+		})
+	}
+
+}
+
+func RulesEqual(a, b []Rule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v.ID != b[i].ID {
+			return false
+		}
+	}
+	return true
+}

--- a/apitestdata/owasp.json
+++ b/apitestdata/owasp.json
@@ -1,0 +1,45 @@
+{
+    "data": {
+        "id": "4HWq26YF12xqZytqTy3LPa",
+        "type": "owasp",
+        "attributes": {
+            "created_at": "2017-01-01T01:01:01Z",
+            "updated_at": "2018-01-01T01:01:01Z",
+            "critical_anomaly_score": 5,
+            "error_anomaly_score": 4,
+            "notice_anomaly_score": 2,
+            "warning_anomaly_score": 3,
+            "http_violation_score_threshold": 5,
+            "inbound_anomaly_score_threshold": 10,
+            "lfi_score_threshold": 5,
+            "php_injection_score_threshold": 5,
+            "rce_score_threshold": 5,
+            "rfi_score_threshold": 5,
+            "session_fixation_score_threshold": 5,
+            "sql_injection_score_threshold": 5,
+            "xss_score_threshold": 5,
+            "paranoia_level": 3,
+            "arg_name_length": 800,
+            "arg_length": 800,
+            "total_arg_length": 6400,
+            "max_file_size": 10000000,
+            "combined_file_sizes": 10000000,
+            "max_num_args": 255,
+            "high_risk_country_codes": null,
+            "allowed_methods": "GET HEAD POST OPTIONS PUT PATCH DELETE",
+            "restricted_headers": "/proxy/ /lock-token/ /content-range/ /translate/ /if/",
+            "restricted_extensions": ".asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx",
+            "allowed_http_versions": "HTTP/1.0 HTTP/1.1 HTTP/2",
+            "allowed_request_content_type": "application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain",
+            "crs_validate_utf8_encoding": false
+        },
+        "relationships": {
+            "waf": {
+                "data": {
+                    "id": "{{waf-id}}",
+                    "type": "waf"
+                }
+            }
+        }
+    }
+}

--- a/apitestdata/rules.json
+++ b/apitestdata/rules.json
@@ -1,0 +1,74 @@
+[
+    {
+        "id": "{{waf-id}}-2200002",
+        "type": "rule_status",
+        "attributes": {
+            "status": "log",
+            "modsec_rule_id": "2200002",
+            "unique_rule_id": "2U0FU05tT1lAT08GCtqomv"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2200000",
+        "type": "rule_status",
+        "attributes": {
+            "status": "block",
+            "modsec_rule_id": "2200000",
+            "unique_rule_id": "6x5k86Jn2HONFI0RS2tI02"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2084113",
+        "type": "rule_status",
+        "attributes": {
+            "status": "block",
+            "modsec_rule_id": "2084113",
+            "unique_rule_id": "74fE7qH0tSiscgEBFSQzYY"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2077878",
+        "type": "rule_status",
+        "attributes": {
+            "status": "log",
+            "modsec_rule_id": "2077878",
+            "unique_rule_id": "6t7QjkjpUrh1Q6rS7q8kio"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2077876",
+        "type": "rule_status",
+        "attributes": {
+            "status": "log",
+            "modsec_rule_id": "2077876",
+            "unique_rule_id": "6I76fUnNtGcxBS2L2l3BtF"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2081321",
+        "type": "rule_status",
+        "attributes": {
+            "status": "log",
+            "modsec_rule_id": "2081321",
+            "unique_rule_id": "2ZGhSVghOoN1LLIASIQYfN"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2016874",
+        "type": "rule_status",
+        "attributes": {
+            "status": "disabled",
+            "modsec_rule_id": "2016874",
+            "unique_rule_id": "5oAGhZVNQwLUjQeIHM8Qxh"
+        }
+    },
+    {
+        "id": "{{waf-id}}-2025198",
+        "type": "rule_status",
+        "attributes": {
+            "status": "log",
+            "modsec_rule_id": "2025198",
+            "unique_rule_id": "1IyF2mdfpCTmjAb0kKkreI"
+        }
+    }
+]

--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Backup is a backup of the rule status for a WAF
+type Backup struct {
+	ServiceID string
+	WAFID     string
+	ID        string
+	Updated   time.Time
+	Disabled  []string
+	Block     []string
+	Log       []string
+	Owasp     OWASPSettings
+}
+
+// backupConfig retrieves from the API and returns all rules, statuses,
+// configuration set, and OWASP settings and saves them to a TOML file
+// at the given path.
+func backupConfig(apiep, apikey, sid, wid, bpath string) (int, error) {
+	b, err := getBackupData(apiep, apikey, sid, wid)
+	if err != nil {
+		return 0, fmt.Errorf("Error while getting backup data. %s", err)
+	}
+
+	ib, err := writeBackupToTOMLFile(b, bpath)
+	if err != nil {
+		return 0, fmt.Errorf("Error while writing backup to disk at `%s`. %s", bpath, err)
+	}
+
+	return ib, nil
+}
+
+// writeBackupToTOMLFile serializes the given backup object to a file at the
+// given path.
+func writeBackupToTOMLFile(b *Backup, bpath string) (int, error) {
+
+	// validate the output path
+	d := filepath.Dir(bpath)
+	if _, err := os.Stat(d); os.IsNotExist(err) {
+		return 0, fmt.Errorf("Output path does not exist: %s", d)
+	}
+
+	// encode the backup to TOML
+	buf := new(bytes.Buffer)
+	if err := toml.NewEncoder(buf).Encode(b); err != nil {
+		return 0, err
+	}
+
+	// write to disk
+	err := ioutil.WriteFile(bpath, buf.Bytes(), 0644)
+	if err != nil {
+		return 0, err
+	}
+
+	return buf.Len(), nil
+}
+
+// getBackupData retrieves from the API and returns all rules, statuses,
+// configuration set, and OWASP settings in a backup structure.
+func getBackupData(apiep, apikey, sid, wid string) (*Backup, error) {
+
+	// retrieve the owasp settings
+	var ow *OWASPSettings
+	var grerr error
+	var wg sync.WaitGroup
+
+	// don't waste time, pull the OWASP settings async while the rules are
+	// being retrieved.
+	go func() {
+		wg.Add(1)
+		ow, grerr = GetOWASPSettings(apiep, apikey, sid, wid)
+		wg.Done()
+	}()
+
+	// retrieve the rules
+	rl, rb, rd, err := GetRules(apiep, apikey, sid, wid)
+	if err != nil {
+		return &Backup{}, fmt.Errorf("Error while getting rules: %s", err)
+	}
+
+	// extract sorted rule ID
+	ll := ruleArrToSortedStringArr(rl)
+	lb := ruleArrToSortedStringArr(rb)
+	ld := ruleArrToSortedStringArr(rd)
+
+	wg.Wait()
+
+	// throw error if problem getting OWASP, but wait for the waitgroup to finish
+	// because it's unreasonable to assume this will always be handled fatally by
+	// the invoker.
+	if grerr != nil {
+		return &Backup{}, fmt.Errorf("Error while getting OWASP settings: %s", err)
+	}
+
+	// create a UID for the backup
+	hasher := sha1.New()
+	hasher.Write([]byte(sid + time.Now().String()))
+	sha := hex.EncodeToString((hasher.Sum(nil)))
+
+	// return the backup object
+	return &Backup{
+		ID:        sha,
+		ServiceID: sid,
+		WAFID:     wid,
+		Disabled:  ld,
+		Block:     lb,
+		Log:       ll,
+		Owasp:     *ow,
+		Updated:   time.Now(),
+	}, nil
+}

--- a/backup_test.go
+++ b/backup_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBackupData(t *testing.T) {
+	tsvr := APIHarness{}
+	p, err := tsvr.Start()
+	if err != nil {
+		t.Fatalf("Error starting API test server. %s", err)
+	}
+
+	apiep := fmt.Sprintf("http://localhost:%d", p)
+	defer tsvr.Stop()
+
+	tests := []struct {
+		testid             string
+		serviceid          string
+		wafid              string
+		expLogRuleIDs      []string
+		expBlockRuleIDs    []string
+		expDisabledRuleIDs []string
+		expOWASP           OWASPSettings
+	}{
+		{
+			"Simple Test",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			[]string{"2200002", "2077878", "2077876", "2081321", "2025198"},
+			[]string{"2084113", "2200000"},
+			[]string{"2016874"},
+			OWASPSettings{
+				ID:                            "4HWq26YF12xqZytqTy3LPa",
+				AllowedHTTPVersions:           "HTTP/1.0 HTTP/1.1 HTTP/2",
+				AllowedMethods:                "GET HEAD POST OPTIONS PUT PATCH DELETE",
+				AllowedRequestContentType:     "application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain",
+				ArgLength:                     800,
+				ArgNameLength:                 800,
+				CombinedFileSizes:             10000000,
+				CreatedAt:                     "2017-01-01T01:01:01Z",
+				CriticalAnomalyScore:          5,
+				CRSValidateUTF8Encoding:       false,
+				ErrorAnomalyScore:             4,
+				HighRiskCountryCodes:          "",
+				HTTPViolationScoreThreshold:   5,
+				InboundAnomalyScoreThreshold:  10,
+				LFIScoreThreshold:             5,
+				MaxFileSize:                   10000000,
+				MaxNumArgs:                    255,
+				NoticeAnomalyScore:            2,
+				ParanoiaLevel:                 3,
+				PHPInjectionScoreThreshold:    5,
+				RCEScoreThreshold:             5,
+				RestrictedExtensions:          ".asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx",
+				RestrictedHeaders:             "/proxy/ /lock-token/ /content-range/ /translate/ /if/",
+				RFIScoreThreshold:             5,
+				SessionFixationScoreThreshold: 5,
+				SQLInjectionScoreThreshold:    5,
+				TotalArgLength:                6400,
+				UpdatedAt:                     "2018-01-01T01:01:01Z",
+				WarningAnomalyScore:           3,
+				XSSScoreThreshold:             5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			b, err := getBackupData(apiep, testAPIKey, tt.serviceid, tt.wafid)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			assert.Equal(t, tt.serviceid, b.ServiceID, "Service ID does not match.")
+			assert.Equal(t, tt.wafid, b.WAFID, "WAF ID does not match.")
+
+			checkRulesStringArr(t, tt.expLogRuleIDs, b.Log, "Log")
+			checkRulesStringArr(t, tt.expBlockRuleIDs, b.Block, "Block")
+			checkRulesStringArr(t, tt.expDisabledRuleIDs, b.Disabled, "Disabled")
+
+			if assert.NotNil(t, b.Owasp, "OWASP is nil.") {
+				assert.Equal(t, tt.expOWASP, b.Owasp, "OWASP attributes do not match.")
+			}
+
+		})
+	}
+}

--- a/owasp.go
+++ b/owasp.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/google/jsonapi"
+	resty "gopkg.in/resty.v1"
+)
+
+// OWASPSettings defines a type intended for serialized TOML output as part of
+// backups & Configuration
+// TODO: This includes extra fields which are relevant to backup, but not neccessarily
+// relevant (perhaps even break) the OWASP update / provision. Test this! Perhaps use sethvargo's library for this.
+type OWASPSettings struct {
+	ID                               string `jsonapi:"primary,owasp"`
+	AllowedHTTPVersions              string `jsonapi:"attr,allowed_http_versions"`
+	AllowedMethods                   string `jsonapi:"attr,allowed_methods"`
+	AllowedRequestContentType        string `jsonapi:"attr,allowed_request_content_type"`
+	AllowedRequestContentTypeCharset string `jsonapi:"attr,allowed_request_content_type_charset"`
+	ArgLength                        int    `jsonapi:"attr,arg_length"`
+	ArgNameLength                    int    `jsonapi:"attr,arg_name_length"`
+	CombinedFileSizes                int    `jsonapi:"attr,combined_file_sizes"`
+	CreatedAt                        string `jsonapi:"attr,created_at"`
+	CriticalAnomalyScore             int    `jsonapi:"attr,critical_anomaly_score"`
+	CRSValidateUTF8Encoding          bool   `jsonapi:"attr,crs_validate_utf8_encoding"`
+	ErrorAnomalyScore                int    `jsonapi:"attr,error_anomaly_score"`
+	HighRiskCountryCodes             string `jsonapi:"attr,high_risk_country_codes"`
+	HTTPViolationScoreThreshold      int    `jsonapi:"attr,http_violation_score_threshold"`
+	InboundAnomalyScoreThreshold     int    `jsonapi:"attr,inbound_anomaly_score_threshold"`
+	LFIScoreThreshold                int    `jsonapi:"attr,lfi_score_threshold"`
+	MaxFileSize                      int    `jsonapi:"attr,max_file_size"`
+	MaxNumArgs                       int    `jsonapi:"attr,max_num_args"`
+	NoticeAnomalyScore               int    `jsonapi:"attr,notice_anomaly_score"`
+	ParanoiaLevel                    int    `jsonapi:"attr,paranoia_level"`
+	PHPInjectionScoreThreshold       int    `jsonapi:"attr,php_injection_score_threshold"`
+	RCEScoreThreshold                int    `jsonapi:"attr,rce_score_threshold"`
+	RestrictedExtensions             string `jsonapi:"attr,restricted_extensions"`
+	RestrictedHeaders                string `jsonapi:"attr,restricted_headers"`
+	RFIScoreThreshold                int    `jsonapi:"attr,rfi_score_threshold"`
+	SessionFixationScoreThreshold    int    `jsonapi:"attr,session_fixation_score_threshold"`
+	SQLInjectionScoreThreshold       int    `jsonapi:"attr,sql_injection_score_threshold"`
+	TotalArgLength                   int    `jsonapi:"attr,total_arg_length"`
+	UpdatedAt                        string `jsonapi:"attr,updated_at"`
+	WarningAnomalyScore              int    `jsonapi:"attr,warning_anomaly_score"`
+	XSSScoreThreshold                int    `jsonapi:"attr,xss_score_threshold"`
+}
+
+// GetOWASPSettings pulls OWASP setting data from the API.
+// Specifying endpoint, api key, service ID, WAF ID.
+func GetOWASPSettings(apiep string, apikey string, sid string, wid string) (*OWASPSettings, error) {
+	ow := OWASPSettings{}
+
+	apiCall := fmt.Sprintf("%s/service/%s/wafs/%s/owasp", apiep, sid, wid)
+
+	resp, err := resty.R().
+		SetHeader("Accept", "application/vnd.api+json").
+		SetHeader("Fastly-Key", apikey).
+		SetHeader("Content-Type", "application/vnd.api+json").
+		Get(apiCall)
+
+	if err != nil {
+		return &ow, fmt.Errorf("Error while making API call to %s", apiCall)
+	}
+
+	// check status
+	if resp.StatusCode() != 200 {
+		return &ow, fmt.Errorf("Non 200 response while making API call to %s", apiCall)
+	}
+
+	// unmarshal the response
+	err = jsonapi.UnmarshalPayload(bytes.NewReader(resp.Body()), &ow)
+	if err != nil {
+		return &ow, fmt.Errorf("Error while parsing API response from %s", apiCall)
+	}
+
+	return &ow, nil
+}

--- a/owasp_test.go
+++ b/owasp_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOWASPSettings(t *testing.T) {
+	tsvr := APIHarness{}
+	p, err := tsvr.Start()
+	if err != nil {
+		t.Fatalf("Error starting API test server. %s", err)
+	}
+
+	apiep := fmt.Sprintf("http://localhost:%d", p)
+	defer tsvr.Stop()
+
+	tests := []struct {
+		testid    string
+		serviceid string
+		wafid     string
+		expected  OWASPSettings
+	}{
+		{
+			"Test 001",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			OWASPSettings{
+				ID:                            "4HWq26YF12xqZytqTy3LPa",
+				AllowedHTTPVersions:           "HTTP/1.0 HTTP/1.1 HTTP/2",
+				AllowedMethods:                "GET HEAD POST OPTIONS PUT PATCH DELETE",
+				AllowedRequestContentType:     "application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain",
+				ArgLength:                     800,
+				ArgNameLength:                 800,
+				CombinedFileSizes:             10000000,
+				CreatedAt:                     "2017-01-01T01:01:01Z",
+				CriticalAnomalyScore:          5,
+				CRSValidateUTF8Encoding:       false,
+				ErrorAnomalyScore:             4,
+				HighRiskCountryCodes:          "",
+				HTTPViolationScoreThreshold:   5,
+				InboundAnomalyScoreThreshold:  10,
+				LFIScoreThreshold:             5,
+				MaxFileSize:                   10000000,
+				MaxNumArgs:                    255,
+				NoticeAnomalyScore:            2,
+				ParanoiaLevel:                 3,
+				PHPInjectionScoreThreshold:    5,
+				RCEScoreThreshold:             5,
+				RestrictedExtensions:          ".asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx",
+				RestrictedHeaders:             "/proxy/ /lock-token/ /content-range/ /translate/ /if/",
+				RFIScoreThreshold:             5,
+				SessionFixationScoreThreshold: 5,
+				SQLInjectionScoreThreshold:    5,
+				TotalArgLength:                6400,
+				UpdatedAt:                     "2018-01-01T01:01:01Z",
+				WarningAnomalyScore:           3,
+				XSSScoreThreshold:             5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			ow, err := GetOWASPSettings(apiep, testAPIKey, tt.serviceid, tt.wafid)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			// Check returned data for equality
+			if assert.NotNil(t, ow, "OWASP is nil.") {
+				assert.Equal(t, &tt.expected, ow, "OWASP attributes do not match.")
+			}
+
+		})
+	}
+}

--- a/rules.go
+++ b/rules.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	resty "gopkg.in/resty.v1"
+)
+
+// GetRules pulls all rule data from the API.
+// Specifying endpoint, api key, service ID, WAF ID.
+// This method pulls first head page which contains metadata describing subsequent
+// pages and then pulls the subsequent pages.
+// Returned Log Rules, Block Rules, Disabled Rules and any Error.
+// Note: Rules are ordered based on when the async responses were processed.
+func GetRules(apiep, apikey, sid, wid string) ([]Rule, []Rule, []Rule, error) {
+	rl, rb, rd := []Rule{}, []Rule{}, []Rule{}
+	// pull the head page & read the meta for following pages
+	rf, err := getRuleHeadPageData(apiep, apikey, sid, wid)
+	if err != nil {
+		return rl, rb, rd, fmt.Errorf("error pulling first page of rules. %s", err)
+	}
+
+	// process the results of the first page
+	for _, r := range rf.Data {
+		switch r.Attributes.Status {
+		case "log":
+			rl = append(rl, r)
+		case "block":
+			rb = append(rb, r)
+		case "disabled":
+			rd = append(rd, r)
+		}
+	}
+
+	in := make(chan inGetRulePagedData)
+	out := make(chan outGetRulePagedData)
+
+	// for joining the async calls for the paged rule data
+	var wgGetRules sync.WaitGroup
+
+	// create a pool of workers for pulling paged data
+	for i := 0; i < 10; i++ {
+		go getRulePagedDataAsync(in, out)
+	}
+
+	// process data from responses on the output channel
+	var rerr error
+	go func() {
+		for r := range out {
+			if r.err != nil {
+				rerr = fmt.Errorf("error(s) pulling pages of rules. %s", r.err)
+			}
+
+			for _, r := range r.rl.Data {
+				switch r.Attributes.Status {
+				case "log":
+					rl = append(rl, r)
+				case "block":
+					rb = append(rb, r)
+				case "disabled":
+					rd = append(rd, r)
+				}
+			}
+			wgGetRules.Done()
+		}
+	}()
+
+	// invoke requests for paged data async
+	for i := 2; i <= rf.Meta.TotalPages; i++ {
+		wgGetRules.Add(1)
+		in <- inGetRulePagedData{apiep, apikey, sid, wid, rf.Meta.PerPage, i}
+	}
+
+	// close input channel since no more jobs are being sent to input channel
+	close(in)
+
+	// wait for all responses to be processed
+	wgGetRules.Wait()
+
+	// close output channel since all workers have finished processing
+	close(out)
+
+	// check for error
+	if rerr != nil {
+		return rl, rb, rd, rerr
+	}
+
+	return rl, rb, rd, nil
+}
+
+// getRuleHeadPageData pulls the first page of data from the API.
+// Specifying endpoint, api key, service ID, WAF ID.
+// This method returns metadata regarding the total size of the dataset allowing
+// retrieval of subsequent pages.
+func getRuleHeadPageData(apiep string, apikey string, sid string, wid string) (RuleList, error) {
+	return getRulePagedData(apiep, apikey, sid, wid, -1, -1)
+}
+
+// getRulePagedData pulls paged data from the API.
+// Specifying endpoint, api key, service ID, WAF ID, records per page and page number.
+func getRulePagedData(apiep string, apikey string, sid string, wid string, pp int, pn int) (RuleList, error) {
+	rl := RuleList{}
+
+	apiCall := fmt.Sprintf("%s/service/%s/wafs/%s/rule_statuses", apiep, sid, wid)
+	if pp != -1 && pn != -1 {
+		apiCall += fmt.Sprintf("?page[number]=%d&page[size]=%d", pn, pp)
+	}
+
+	resp, err := resty.R().
+		SetHeader("Accept", "application/vnd.api+json").
+		SetHeader("Fastly-Key", apikey).
+		SetHeader("Content-Type", "application/vnd.api+json").
+		Get(apiCall)
+
+	if err != nil {
+		return rl, fmt.Errorf("Error while making API call to %s", apiCall)
+	}
+
+	// check status
+	if resp.StatusCode() != 200 {
+		return rl, fmt.Errorf("Non 200 response while making API call to %s", apiCall)
+	}
+
+	// unmarshal the response
+	err = json.Unmarshal(resp.Body(), &rl)
+	if err != nil {
+		return rl, fmt.Errorf("Error while parsing API response from %s", apiCall)
+	}
+
+	return rl, nil
+}
+
+// inGetRulePagedData defines the input parameters for getRulePagedData so data
+// can be sent down a channel
+type inGetRulePagedData struct {
+	apiep  string
+	apikey string
+	sid    string
+	wid    string
+	pp     int
+	pn     int
+}
+
+// outGetRulePagedData defines output parameters for getRulePagedData so the
+// response can be sent up the output channel
+type outGetRulePagedData struct {
+	rl  RuleList
+	err error
+}
+
+// getRulePagedDataAsync provides input/output channels for async execution of
+// getRulePagedData. Because it wraps getRulePagedData, it allows it to be testable.
+func getRulePagedDataAsync(in chan inGetRulePagedData, out chan outGetRulePagedData) {
+	for v := range in {
+		rn, err := getRulePagedData(v.apiep, v.apikey, v.sid, v.wid, v.pp, v.pn)
+		out <- outGetRulePagedData{rn, err}
+	}
+}
+
+// ruleArrToSortedStringArr translates a slice of Rule into a slice of string,
+// identifying the rule by it's ModsecRuleID
+func ruleArrToSortedStringArr(rl []Rule) []string {
+	var ret []string
+	for _, r := range rl {
+		ret = append(ret, r.Attributes.ModsecRuleID)
+	}
+	sort.Strings(ret)
+
+	return ret
+}

--- a/rules_test.go
+++ b/rules_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRuleHeadPageData(t *testing.T) {
+	tsvr := APIHarness{}
+	p, err := tsvr.Start()
+	if err != nil {
+		t.Fatalf("Error starting API test server. %s", err)
+	}
+
+	apiep := fmt.Sprintf("http://localhost:%d", p)
+	defer tsvr.Stop()
+
+	tests := []struct {
+		testid          string
+		serviceid       string
+		wafid           string
+		expPageLen      int
+		expMetaTotal    int
+		expMetaNumPages int
+		expFirstRuleID  string
+	}{
+		{
+			"Test 001",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			3,
+			8,
+			3,
+			"2200002",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			rl, err := getRuleHeadPageData(apiep, testAPIKey, tt.serviceid, tt.wafid)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			assert.Equal(t, tt.expPageLen, len(rl.Data), "Number of rules does not match.")
+			assert.Equal(t, tt.expMetaTotal, rl.Meta.RecordCount, "Total number of rules does not match.")
+			assert.Equal(t, tt.expMetaNumPages, rl.Meta.TotalPages, "Total number of pages does not match.")
+			assert.Equal(t, tt.expFirstRuleID, rl.Data[0].Attributes.ModsecRuleID, "First rule ID does not match.")
+
+		})
+	}
+}
+
+func TestGetRulePagedData(t *testing.T) {
+	tsvr := APIHarness{}
+	p, err := tsvr.Start()
+	if err != nil {
+		t.Fatalf("Error starting API test server. %s", err)
+	}
+
+	apiep := fmt.Sprintf("http://localhost:%d", p)
+	defer tsvr.Stop()
+
+	tests := []struct {
+		testid         string
+		serviceid      string
+		wafid          string
+		expPerPage     int
+		expPageNo      int
+		expPageLen     int
+		expFirstRuleID string
+	}{
+		{
+			"2nd Page",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			3,
+			2,
+			3,
+			"2077878",
+		},
+		{
+			"3rd Page",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			3,
+			3,
+			2,
+			"2016874",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			rl, err := getRulePagedData(apiep, testAPIKey, tt.serviceid, tt.wafid, tt.expPerPage, tt.expPageNo)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			assert.Equal(t, tt.expPerPage, rl.Meta.PerPage, "Total number of rules per page does not match.")
+			assert.Equal(t, tt.expPageNo, rl.Meta.CurrentPage, "Current Page does not match.")
+			assert.Equal(t, tt.expPageLen, len(rl.Data), "Number of rules does not match.")
+			assert.Equal(t, tt.expFirstRuleID, rl.Data[0].Attributes.ModsecRuleID, "First rule ID does not match.")
+
+		})
+	}
+
+}
+
+func TestGetRules(t *testing.T) {
+	tsvr := APIHarness{}
+	p, err := tsvr.Start()
+	if err != nil {
+		t.Fatalf("Error starting API test server. %s", err)
+	}
+
+	apiep := fmt.Sprintf("http://localhost:%d", p)
+	defer tsvr.Stop()
+
+	tests := []struct {
+		testid             string
+		serviceid          string
+		wafid              string
+		expLogRuleIDs      []string
+		expBlockRuleIDs    []string
+		expDisabledRuleIDs []string
+	}{
+		{
+			"Test 001",
+			"[REDACTED-SID]",
+			"[REDACTED-WAFID]",
+			[]string{"2200002", "2077878", "2077876", "2081321", "2025198"},
+			[]string{"2084113", "2200000"},
+			[]string{"2016874"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testid, func(t *testing.T) {
+
+			rl, rb, rd, err := GetRules(apiep, testAPIKey, tt.serviceid, tt.wafid)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			checkRules(t, tt.expLogRuleIDs, rl, "Log")
+			checkRules(t, tt.expBlockRuleIDs, rb, "Block")
+			checkRules(t, tt.expDisabledRuleIDs, rd, "Disabled")
+		})
+	}
+}
+
+func checkRules(t *testing.T, exp []string, act []Rule, text string) {
+	var ar []string
+	for _, r := range act {
+		ar = append(ar, r.Attributes.ModsecRuleID)
+	}
+	checkRulesStringArr(t, exp, ar, text)
+}
+
+func checkRulesStringArr(t *testing.T, exp []string, act []string, text string) {
+	assert.Equal(t, len(exp), len(act), fmt.Sprintf("Number of %s rules.", text))
+	for _, er := range exp {
+		var f bool
+		for _, ar := range act {
+			if er == ar {
+				f = true
+				break
+			}
+		}
+		assert.Equal(t, true, f, fmt.Sprintf("Rule %s not found in %s rules.", er, text))
+	}
+}
+
+func rulesToString(r []Rule) string {
+	var rs string
+	rsa := ruleArrToSortedStringArr(r)
+	for _, r := range rsa {
+		rs += r + ", "
+	}
+	return strings.TrimSuffix(rs, ", ")
+}

--- a/waflyctl_test.go
+++ b/waflyctl_test.go
@@ -1,0 +1,3 @@
+package main
+
+const testAPIKey string = "[REDACTED-APIKEY]"


### PR DESCRIPTION
Main objective of this PR is to start breaking down some of these mammoth code blocks into functions and separate files so the code is better compartmentalized and lends itself better to unit tests etc.
I was keen to get a test framework in place before starting with the `restore` functionality.

Most significant/controversial additions:
 - Wanted a way to test the parsing and handling of data returned from the API, Resty doesn't appear to allow us to break this apart, so opted for creating an ephemeral test endpoint which emulates the Fastly API and configurable with test-data within the project.
 - Pulling rule/owasp data was unnecessarily slow, added basic worker pool for pulling data, significantly improves performance. Currently 10 goroutines, but size of pool can easily be altered.

Note: Still needs a little tidy up in places, see TODOs.