### PR TITLE
Various refactoring.

### DIFF
--- a/Documentation/EXAMPLES.md
+++ b/Documentation/EXAMPLES.md
@@ -3,7 +3,7 @@
 Replace <service_id> and <configuration_set_id> where appropriate.
 
 ## Provision a Service with OWASP rule set
-`waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --tags OWASP`
+`waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --tags OWASP --comment "WAF deployment"`
 
 ## Add three rules to block mode on a Service with a WAF provisioned
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --rules 1010010,931100,931110 --action block`
@@ -32,5 +32,5 @@ Replace <service_id> and <configuration_set_id> where appropriate.
 ## Disable WAF in case of an emergency
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --status disable`
 
-## Customer with shielding
+## Customer with shielding (deprecated - no longer required)
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --enable-logs-only --with-shielding`

--- a/config_examples/waflyctl.toml.example
+++ b/config_examples/waflyctl.toml.example
@@ -46,6 +46,7 @@ name = "weblogs"
 address = "address"
 port = 514
 format = '''{\"type\":\"req\",\"service_id\":\"%{req.service_id}V\",\"request_id\":\"%{req.http.fastly-soc-x-request-id}V\",\"start_time\":\"%{time.start.sec}V\",\"fastly_info\":\"%{fastly_info.state}V\",\"datacenter\":\"%{server.datacenter}V\",\"client_ip\":\"%a\",\"req_method\":\"%m\",\"req_uri\":\"%{cstr_escape(req.url)}V\",\"req_h_host\":\"%{cstr_escape(req.http.Host)}V\",\"req_h_user_agent\":\"%{cstr_escape(req.http.User-Agent)}V\",\"req_h_accept_encoding\":\"%{cstr_escape(req.http.Accept-Encoding)}V\",\"req_header_bytes\":\"%{req.header_bytes_read}V\",\"req_body_bytes\":\"%{req.body_bytes_read}V\",\"waf_logged\":\"%{waf.logged}V\",\"waf_blocked\":\"%{waf.blocked}V\",\"waf_failures\":\"%{waf.failures}V\",\"waf_executed\":\"%{waf.executed}V\",\"anomaly_score\":\"%{waf.anomaly_score}V\",\"sql_injection_score\":\"%{waf.sql_injection_score}V\",\"rfi_score\":\"%{waf.rfi_score}V\",\"lfi_score\":\"%{waf.lfi_score}V\",\"rce_score\":\"%{waf.rce_score}V\",\"php_injection_score\":\"%{waf.php_injection_score}V\",\"session_fixation_score\":\"%{waf.session_fixation_score}V\",\"http_violation_score\":\"%{waf.http_violation_score}V\",\"xss_score\":\"%{waf.xss_score}V\",\"resp_status\":\"%{resp.status}V\",\"resp_bytes\":\"%{resp.bytes_written}V\",\"resp_header_bytes\":\"%{resp.header_bytes_written}V\",\"resp_body_bytes\":\"%{resp.body_bytes_written}V\"}'''
+condition = "waf.executed"
 
 [waflog]
 name = "waflogs"


### PR DESCRIPTION
- Cleaned up logging condition code
- Removed --with-shielding related code
- Added 'Condition' to toml -> weblogs configuration. Default value 'waf.logged' used if not present
- Version validation now called only if a new version has been created
- Modifications to backup so that the generated output matches the format of the toml file for easier transfer (e.g. Disabled -> DisabledRules and rule IDs as ints rather than strings).