### PR TITLE
Minor documentation glitches

### DIFF
--- a/Documentation/BUILD.md
+++ b/Documentation/BUILD.md
@@ -1,12 +1,12 @@
-#  Build
+# Build
 
 Install [Go](https://golang.org/doc/install) and run the following
 commands:
 
 ```
 cd waflyctl
-go get github.com/BurntSushi/toml github.com/sethvargo/go-fastly/fastly \
-	gopkg.in/alecthomas/kingpin.v2 gopkg.in/resty.v1
-go build waflyctl.go
+go get github.com/BurntSushi/toml github.com/fastly/go-fastly \
+  gopkg.in/alecthomas/kingpin.v2 gopkg.in/resty.v1
+go build -mod=vendor waflyctl.go
 ./waflyctl
 ```

--- a/Documentation/CONTRIBUTING.md
+++ b/Documentation/CONTRIBUTING.md
@@ -11,4 +11,3 @@
   Explanation of new behaviour. Link to issue that is addressed. Ensure
   documentation contains the correct information.
 - Pull requests will be reviewed and hopefully merged into a release.
-

--- a/Documentation/CONTRIBUTING.md
+++ b/Documentation/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
- We welcome community contribution to this repository. To help add
- functionality or address issued please take the following steps:
+We welcome community contribution to this repository. To help add
+functionality or address issued please take the following steps:
 
 - Fork the repository from the master branch.
 - Create a new branch for your features / fixes.

--- a/Documentation/EXAMPLES.md
+++ b/Documentation/EXAMPLES.md
@@ -3,34 +3,45 @@
 Replace <service_id> and <configuration_set_id> where appropriate.
 
 ## Provision a Service with OWASP rule set
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --tags OWASP`
 
 ## Add three rules to block mode on a Service with a WAF provisioned
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --rules 1010010,931100,931110 --action block`
 
 ## Delete a WAF previously provisioned
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --delete`
 
 ## Customer with PerimeterX bot protection
+
 `waflyctl --apikey $FASTLY_TOKEN --domain myexample.com --with-perimeterx`
 
 ## Only edit OWASP object base on what it is set on the config file
+
 `waflyctl --apikey $FASTLY_TOKEN --domain myexample.com --owasp`
 
 ## Listing all configuration sets available on the fastly platform
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --list-configuration-sets`
 
 ## Listing all rules available under a configuration set
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --list-all-rules <configuration_set_id>`
 
 ## Listing all rules and their status for a service
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --list-rules`
 
-## Set all rules of publisher owasp to logging 
+## Set all rules of publisher owasp to logging
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --publisher owasp --action log`
 
 ## Disable WAF in case of an emergency
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --status disable`
 
 ## Customer with shielding
+
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --enable-logs-only --with-shielding`

--- a/Documentation/INSTALLATION.md
+++ b/Documentation/INSTALLATION.md
@@ -1,11 +1,11 @@
 # Requirements
 
-* Have a Fastly API Key in-hand with edit privileges
-* Have a service behind Fastly
-* Have WAF enabled for your account
-* You will also need to grab a copy of the
-[config](https://github.com/fastly/waflyctl/blob/master/config_examples/waflyctl.toml.example)
-file and place it under `~/.waflyctl.toml` where the tool defaults to.
+- Have a Fastly API Key in-hand with edit privileges
+- Have a service behind Fastly
+- Have WAF enabled for your account
+- You will also need to grab a copy of the
+  [config](https://github.com/fastly/waflyctl/blob/master/config_examples/waflyctl.toml.example)
+  file and place it under `~/.waflyctl.toml` where the tool defaults to.
 
 # Mac Installation
 
@@ -24,7 +24,6 @@ brew install --HEAD fastly/tap/waflyctl
 # Other OS Installation
 
 Install Go: https://golang.org/doc/install
-
 
 Download, install, build waflyctl + dependencies:
 

--- a/Documentation/OPENING-ISSUES.md
+++ b/Documentation/OPENING-ISSUES.md
@@ -15,4 +15,4 @@ A good bug report contains the data necessary to reproduce, identify, locate
 and address a problem in code. Where possible it should also indicate what
 steps have already been taken to address the issue and their result too.
 
-A report should be reproducible on a base install of waflyctl. 
+A report should be reproducible on a base install of waflyctl.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Fastly WAF Control Tool 
+# Fastly WAF Control Tool
 
 ![Fastly WAF Control Tool](images/waflyctl_logo.png)
 
-[![Build Status](https://travis-ci.com/fastly/waflyctl.svg?token=83kKx7scGq3h69fnK6JA&branch=master)](https://travis-ci.com/fastly/waflyctl) 
+[![Build Status](https://travis-ci.com/fastly/waflyctl.svg?token=83kKx7scGq3h69fnK6JA&branch=master)](https://travis-ci.com/fastly/waflyctl)
 
 Thank you for using the "Fastly WAF Control Tool", you will find the latest version in the
 [release](https://github.com/fastly/waflyctl/releases) page.
 
-* rapidly and easily provision a waf object with:
-  * pre-determine rules
-  * OWASP configurations
-  * Response and logging endpoints. 
-* manage WAF rules, and their status. 
-* toggle WAF status on/off
-* manage logging endpoints
+- rapidly and easily provision a waf object with:
+  - pre-determine rules
+  - OWASP configurations
+  - Response and logging endpoints.
+- manage WAF rules, and their status.
+- toggle WAF status on/off
+- manage logging endpoints
 
 ## Contents
 
@@ -49,5 +49,6 @@ If there are issues/errors with integrating the module, please post
 [details](Documentation/OPENING-ISSUES.md) in the GitHub repository issues.
 
 ## Contributing
+
 We welcome pull requests for issues and new functionality. Please see
 [Contributing](Documentation/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
* dependency link updated: `github.com/sethvargo/go-fastly/fastly` -> `github.com/fastly/go-fastly`
* use `-mod=vendor` while building `waflyctl`
* trailing/leading whitespaces
* consistent bullet points across all `*.md` files