### PR TITLE
Remove --domain flag from examples

### DIFF
--- a/Documentation/EXAMPLES.md
+++ b/Documentation/EXAMPLES.md
@@ -12,10 +12,10 @@ Replace <service_id> and <configuration_set_id> where appropriate.
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --delete`
 
 ## Customer with PerimeterX bot protection
-`waflyctl --apikey $FASTLY_TOKEN --domain myexample.com --with-perimeterx`
+`waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --with-perimeterx`
 
 ## Only edit OWASP object base on what it is set on the config file
-`waflyctl --apikey $FASTLY_TOKEN --domain myexample.com --owasp`
+`waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --owasp`
 
 ## Listing all configuration sets available on the fastly platform
 `waflyctl --apikey $FASTLY_TOKEN --serviceid <service_id> --list-configuration-sets`


### PR DESCRIPTION
It looks like this option was deprecated and removed in favour of --serviceid.