### PR TITLE
message correction on waf log configuration when provision waf 

### DIFF
--- a/waflyctl.go
+++ b/waflyctl.go
@@ -462,7 +462,7 @@ func fastlyLogging(client *fastly.Client, serviceID string, config TOMLConfig, v
 			Error.Fatalf("Cannot create logging endpoint %q: CreateSyslog: %v\n", config.Waflog.Name, err)
 		}
 	} else {
-		Warning.Printf("Empty or invalid web log configuration, skipping\n")
+		Warning.Printf("Empty or invalid waf log configuration, skipping\n")
 	}
 }
 


### PR DESCRIPTION
The log configuration section contains two part, one is web log configuration, another is waf log configuration. However the error message only reflects on web log configuration.  

This PR  will update the WARNNG message from: 

WARNING: 2020/07/09 17:21:51 waflyctl.go:438: Empty or invalid **web** log configuration, skipping
WARNING: 2020/07/09 17:21:51 waflyctl.go:465: Empty or invalid **web** log configuration, skipping

to 

WARNING: 2020/07/10 15:55:21 waflyctl.go:438: Empty or invalid **web** log configuration, skipping
WARNING: 2020/07/10 15:55:21 waflyctl.go:465: Empty or invalid **waf** log configuration, skipping
