### PR TITLE
Update to requirements to differentiate WAF (legacy) / WAF-NG

### DIFF
--- a/Documentation/INSTALLATION.md
+++ b/Documentation/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 - Have a Fastly API Key in-hand with edit privileges
 - Have a service behind Fastly
-- Have [Fastly WAF (Legacy)](https://docs.fastly.com/en/guides/web-application-firewall-legacy) enabled for your account. (WAF-NG users should use the [API](https://developer.fastly.com/reference/api/waf/) / [Terraform provider](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_waf_configuration))
+- Have [Fastly WAF (Legacy)](https://docs.fastly.com/en/guides/web-application-firewall-legacy) enabled for your account. (WAF-NG users should use the [API](https://developer.fastly.com/reference/api/waf/) / [Terraform provider](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_waf_configuration) instead)
 - You will also need to grab a copy of the
   [config](https://github.com/fastly/waflyctl/blob/master/config_examples/waflyctl.toml.example)
   file and place it under `~/.waflyctl.toml` where the tool defaults to.

--- a/Documentation/INSTALLATION.md
+++ b/Documentation/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 - Have a Fastly API Key in-hand with edit privileges
 - Have a service behind Fastly
-- Have WAF enabled for your account
+- Have [Fastly WAF (Legacy)](https://docs.fastly.com/en/guides/web-application-firewall-legacy) enabled for your account. (WAF-NG users should use the [API](https://developer.fastly.com/reference/api/waf/) / [Terraform provider](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_waf_configuration))
 - You will also need to grab a copy of the
   [config](https://github.com/fastly/waflyctl/blob/master/config_examples/waflyctl.toml.example)
   file and place it under `~/.waflyctl.toml` where the tool defaults to.


### PR DESCRIPTION
As per the title. I've had a customer trying to still use WAFLYCTL for WAF-NG and there are nearly no references in the repo to indicate this should *not* be used for it. 
The purpose here is to help avoid any confusion between the two.